### PR TITLE
feat: separate eslintrc.json for js and test files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.22.20",
+        "@types/jest": "^29.5.5",
         "eslint": "^8.49.0",
         "eslint-plugin-jest": "^27.4.0",
         "eslint-plugin-jsdoc": "^46.8.1",
@@ -1128,38 +1129,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/@jest/core/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/@jest/core/node_modules/supports-color": {
       "version": "7.2.0",
@@ -2416,6 +2385,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.5.tgz",
+      "integrity": "sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/jsdom": {
@@ -5208,38 +5187,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-circus/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
-    },
     "node_modules/jest-circus/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5695,38 +5642,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/jest-config/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
-    },
     "node_modules/jest-config/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5868,38 +5783,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-each/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-each/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/jest-each/node_modules/supports-color": {
       "version": "7.2.0",
@@ -6180,18 +6063,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-leak-detector/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/jest-leak-detector/node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -6200,26 +6071,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-leak-detector/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-leak-detector/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
@@ -6326,38 +6177,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/jest-matcher-utils/node_modules/supports-color": {
       "version": "7.2.0",
@@ -6483,38 +6302,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/jest-message-util/node_modules/supports-color": {
       "version": "7.2.0",
@@ -7935,38 +7722,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
-    },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -8261,38 +8016,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-validate/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
     },
     "node_modules/jest-validate/node_modules/supports-color": {
       "version": "7.2.0",
@@ -9203,6 +8926,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -9272,6 +9021,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -10779,31 +10534,6 @@
             }
           }
         },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11814,6 +11544,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.5.tgz",
+      "integrity": "sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/jsdom": {
@@ -13946,31 +13686,6 @@
             "yocto-queue": "^0.1.0"
           }
         },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14308,31 +14023,6 @@
             "lines-and-columns": "^1.1.6"
           }
         },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -14442,31 +14132,6 @@
           "version": "29.6.3",
           "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
           "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         },
         "supports-color": {
@@ -14686,33 +14351,10 @@
         "pretty-format": "^29.7.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        },
         "jest-get-type": {
           "version": "29.6.3",
           "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
           "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
       }
@@ -14791,31 +14433,6 @@
           "version": "29.6.3",
           "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
           "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         },
         "supports-color": {
@@ -14916,31 +14533,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         },
         "supports-color": {
@@ -16069,31 +15661,6 @@
             }
           }
         },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-          "dev": true
-        },
         "semver": {
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -16322,31 +15889,6 @@
           "version": "29.6.3",
           "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
           "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "29.7.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-          "dev": true,
-          "requires": {
-            "@jest/schemas": "^29.6.3",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         },
         "supports-color": {
@@ -16977,6 +16519,25 @@
         }
       }
     },
+    "pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -17015,6 +16576,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "require-directory": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
     "test": "jest --coverage --coverageDirectory=./coverage -- tests/screen-reader-speak.test.js",
     "build": "node build.js && uglifyjs dist/screen-reader-speak.js --mangle --webkit --compress \"drop_console=true,passes=5\" -o dist/screen-reader-speak.min.js && jest",
     "jsdoc": "jsdoc -c jsdoc.conf.json",
-    "eslint": "eslint --max-warnings=0 src/*.js",
-    "eslint:fix": "eslint --fix src/*.js"
+    "eslint": "eslint --max-warnings=0 src/*.js tests/*.js",
+    "eslint:fix": "eslint --fix src/*.js tests/*.js"
   },
   "author": "Rancoud",
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.22.20",
+    "@types/jest": "^29.5.5",
     "eslint": "^8.49.0",
     "eslint-plugin-jest": "^27.4.0",
     "eslint-plugin-jsdoc": "^46.8.1",

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,18 +1,16 @@
 {
     "env": {
-        "browser": true,
-        "jest": true
+        "browser": true
     },
     "globals": {
         "Promise": "off"
     },
-    "extends": ["eslint:all", "plugin:jest/recommended"],
+    "extends": ["eslint:all"],
     "parserOptions": {
         "ecmaVersion": 5
     },
     "plugins": [
-        "jsdoc",
-        "jest"
+        "jsdoc"
     ],
     "rules": {
         "array-element-newline": ["error", "consistent"],

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+    "env": {
+        "browser": true,
+        "jest": true,
+        "es6": true
+    },
+    "globals": {
+        "Promise": "off"
+    },
+    "extends": ["eslint:recommended", "plugin:jest/recommended"],
+    "parserOptions": {
+        "ecmaVersion": "latest"
+    },
+    "plugins": [
+        "jest"
+    ]
+}

--- a/tests/screen-reader-speak-dist-min.test.js
+++ b/tests/screen-reader-speak-dist-min.test.js
@@ -1,11 +1,10 @@
-jest.useFakeTimers();
+const dateNow = 1479427200000;
+
+jest.useFakeTimers({now: dateNow});
 
 describe("screen-reader-speak", function(){
-    const dateNow = 1479427200000;
-
     beforeEach(function() {
         document.body.innerHTML = `<html lang="en"><body></body></html>`;
-        jest.spyOn(Date, "now").mockImplementation(() => dateNow);
         require("../dist/screen-reader-speak.min");
     });
 
@@ -13,13 +12,11 @@ describe("screen-reader-speak", function(){
         return document.getElementsByTagName("div")[0];
     }
 
-    it("should be defined", function(done) {
+    it("should be defined", () => {
         expect(window.screenReaderSpeak).toBeDefined();
-
-        done();
     });
 
-    it("should add div in body", function(done) {
+    it("should add div in body", () => {
         let err = window.screenReaderSpeak("sample");
         expect(err).toBeUndefined();
 
@@ -30,11 +27,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("id")).toBe("speak-" + dateNow);
         expect(div.getAttribute("class")).toBe("sr-only");
         expect(div.innerHTML).toBe("");
-
-        done();
     });
 
-    it("should add text in div after 100ms", function(done) {
+    it("should add text in div after 100ms", () => {
         let err = window.screenReaderSpeak("sample 100ms");
         expect(err).toBeUndefined();
 
@@ -46,11 +41,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("id")).toBe("speak-" + dateNow);
         expect(div.getAttribute("class")).toBe("sr-only");
         expect(div.innerHTML).toBe("sample 100ms");
-
-        done();
     });
 
-    it("should delete div in body after 1000ms", function(done) {
+    it("should delete div in body after 1000ms", () => {
         let err = window.screenReaderSpeak("sample 1000ms");
         expect(err).toBeUndefined();
 
@@ -62,11 +55,9 @@ describe("screen-reader-speak", function(){
         jest.clearAllTimers();
 
         expect(getFirstDivInBody()).toBeUndefined();
-
-        done();
     });
 
-    it("should return TypeError for text argument", function(done) {
+    it("should return TypeError for text argument", () => {
         let err;
 
         err = window.screenReaderSpeak(1);
@@ -113,11 +104,9 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(TypeError);
         expect(err.message).toBe("Invalid argument text, expect string, get function");
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should return TypeError for priority argument", function(done) {
+    it("should return TypeError for priority argument", () => {
         let err;
         let div;
 
@@ -173,27 +162,23 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(TypeError);
         expect(err.message).toBe("Invalid argument priority, expect string, get function");
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should block xss html", function(done) {
-        let err = window.screenReaderSpeak("<img src='x' onerror='alert(1)'>");
+    it("should block xss html", () => {
+        let err = window.screenReaderSpeak("<img src='x' onerror='alert(1)' alt=''>");
         expect(err).toBeUndefined();
 
         jest.advanceTimersByTime(100);
         const div = getFirstDivInBody();
-        expect(div.innerHTML).toBe("&lt;img src='x' onerror='alert(1)'&gt;");
+        expect(div.innerHTML).toBe("&lt;img src='x' onerror='alert(1)' alt=''&gt;");
 
         jest.advanceTimersByTime(1000);
         jest.clearAllTimers();
 
         expect(getFirstDivInBody()).toBeUndefined();
-
-        done();
     });
 
-    it("should use correct aria-live values", function(done) {
+    it("should use correct aria-live values", () => {
         let err;
         let div;
 
@@ -238,11 +223,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("aria-live")).toBe("polite");
         document.body.innerHTML = `<html lang="en"><body></body></html>`;
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should not throw error when manipulate dom after purged", function(done) {
+    it("should not throw error when manipulate dom after purged", () => {
         let err = window.screenReaderSpeak("");
         expect(err).toBeUndefined();
 
@@ -250,11 +233,9 @@ describe("screen-reader-speak", function(){
 
         jest.advanceTimersByTime(100);
         jest.advanceTimersByTime(1000);
-
-        done();
     });
 
-    it("should not throw error when manipulate dom after having undefined document.body + should do return ReferenceError when having no document.body", function(done) {
+    it("should not throw error when manipulate dom after having undefined document.body + should do return ReferenceError when having no document.body", () => {
         let err = window.screenReaderSpeak("");
         expect(err).toBeUndefined();
 
@@ -270,7 +251,5 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(ReferenceError);
         expect(err.message).toBe("document.body not exist");
         jest.clearAllTimers();
-
-        done();
     });
 });

--- a/tests/screen-reader-speak-dist.test.js
+++ b/tests/screen-reader-speak-dist.test.js
@@ -1,11 +1,10 @@
-jest.useFakeTimers();
+const dateNow = 1479427200000;
+
+jest.useFakeTimers({now: dateNow});
 
 describe("screen-reader-speak", function(){
-    const dateNow = 1479427200000;
-
     beforeEach(function() {
         document.body.innerHTML = `<html lang="en"><body></body></html>`;
-        jest.spyOn(Date, "now").mockImplementation(() => dateNow);
         require("../dist/screen-reader-speak");
     });
 
@@ -13,13 +12,11 @@ describe("screen-reader-speak", function(){
         return document.getElementsByTagName("div")[0];
     }
 
-    it("should be defined", function(done) {
+    it("should be defined", () => {
         expect(window.screenReaderSpeak).toBeDefined();
-
-        done();
     });
 
-    it("should add div in body", function(done) {
+    it("should add div in body", () => {
         let err = window.screenReaderSpeak("sample");
         expect(err).toBeUndefined();
 
@@ -30,11 +27,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("id")).toBe("speak-" + dateNow);
         expect(div.getAttribute("class")).toBe("sr-only");
         expect(div.innerHTML).toBe("");
-
-        done();
     });
 
-    it("should add text in div after 100ms", function(done) {
+    it("should add text in div after 100ms", () => {
         let err = window.screenReaderSpeak("sample 100ms");
         expect(err).toBeUndefined();
 
@@ -46,11 +41,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("id")).toBe("speak-" + dateNow);
         expect(div.getAttribute("class")).toBe("sr-only");
         expect(div.innerHTML).toBe("sample 100ms");
-
-        done();
     });
 
-    it("should delete div in body after 1000ms", function(done) {
+    it("should delete div in body after 1000ms", () => {
         let err = window.screenReaderSpeak("sample 1000ms");
         expect(err).toBeUndefined();
 
@@ -62,11 +55,9 @@ describe("screen-reader-speak", function(){
         jest.clearAllTimers();
 
         expect(getFirstDivInBody()).toBeUndefined();
-
-        done();
     });
 
-    it("should return TypeError for text argument", function(done) {
+    it("should return TypeError for text argument", () => {
         let err;
 
         err = window.screenReaderSpeak(1);
@@ -113,11 +104,9 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(TypeError);
         expect(err.message).toBe("Invalid argument text, expect string, get function");
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should return TypeError for priority argument", function(done) {
+    it("should return TypeError for priority argument", () => {
         let err;
         let div;
 
@@ -173,27 +162,23 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(TypeError);
         expect(err.message).toBe("Invalid argument priority, expect string, get function");
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should block xss html", function(done) {
-        let err = window.screenReaderSpeak("<img src='x' onerror='alert(1)'>");
+    it("should block xss html", () => {
+        let err = window.screenReaderSpeak("<img src='x' onerror='alert(1)' alt=''>");
         expect(err).toBeUndefined();
 
         jest.advanceTimersByTime(100);
         const div = getFirstDivInBody();
-        expect(div.innerHTML).toBe("&lt;img src='x' onerror='alert(1)'&gt;");
+        expect(div.innerHTML).toBe("&lt;img src='x' onerror='alert(1)' alt=''&gt;");
 
         jest.advanceTimersByTime(1000);
         jest.clearAllTimers();
 
         expect(getFirstDivInBody()).toBeUndefined();
-
-        done();
     });
 
-    it("should use correct aria-live values", function(done) {
+    it("should use correct aria-live values", () => {
         let err;
         let div;
 
@@ -238,11 +223,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("aria-live")).toBe("polite");
         document.body.innerHTML = `<html lang="en"><body></body></html>`;
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should not throw error when manipulate dom after purged", function(done) {
+    it("should not throw error when manipulate dom after purged", () => {
         let err = window.screenReaderSpeak("");
         expect(err).toBeUndefined();
 
@@ -250,11 +233,9 @@ describe("screen-reader-speak", function(){
 
         jest.advanceTimersByTime(100);
         jest.advanceTimersByTime(1000);
-
-        done();
     });
 
-    it("should not throw error when manipulate dom after having undefined document.body + should do return ReferenceError when having no document.body", function(done) {
+    it("should not throw error when manipulate dom after having undefined document.body + should do return ReferenceError when having no document.body", () => {
         let err = window.screenReaderSpeak("");
         expect(err).toBeUndefined();
 
@@ -270,7 +251,5 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(ReferenceError);
         expect(err.message).toBe("document.body not exist");
         jest.clearAllTimers();
-
-        done();
     });
 });

--- a/tests/screen-reader-speak.test.js
+++ b/tests/screen-reader-speak.test.js
@@ -1,11 +1,10 @@
-jest.useFakeTimers();
+const dateNow = 1479427200000;
+
+jest.useFakeTimers({now: dateNow});
 
 describe("screen-reader-speak", function(){
-    const dateNow = 1479427200000;
-
     beforeEach(function() {
         document.body.innerHTML = `<html lang="en"><body></body></html>`;
-        jest.spyOn(Date, "now").mockImplementation(() => dateNow);
         require("../src/screen-reader-speak");
     });
 
@@ -13,13 +12,11 @@ describe("screen-reader-speak", function(){
         return document.getElementsByTagName("div")[0];
     }
 
-    it("should be defined", function(done) {
+    it("should be defined", () => {
         expect(window.screenReaderSpeak).toBeDefined();
-
-        done();
     });
 
-    it("should add div in body", function(done) {
+    it("should add div in body", () => {
         let err = window.screenReaderSpeak("sample");
         expect(err).toBeUndefined();
 
@@ -30,11 +27,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("id")).toBe("speak-" + dateNow);
         expect(div.getAttribute("class")).toBe("sr-only");
         expect(div.innerHTML).toBe("");
-
-        done();
     });
 
-    it("should add text in div after 100ms", function(done) {
+    it("should add text in div after 100ms", () => {
         let err = window.screenReaderSpeak("sample 100ms");
         expect(err).toBeUndefined();
 
@@ -46,11 +41,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("id")).toBe("speak-" + dateNow);
         expect(div.getAttribute("class")).toBe("sr-only");
         expect(div.innerHTML).toBe("sample 100ms");
-
-        done();
     });
 
-    it("should delete div in body after 1000ms", function(done) {
+    it("should delete div in body after 1000ms", () => {
         let err = window.screenReaderSpeak("sample 1000ms");
         expect(err).toBeUndefined();
 
@@ -62,11 +55,9 @@ describe("screen-reader-speak", function(){
         jest.clearAllTimers();
 
         expect(getFirstDivInBody()).toBeUndefined();
-
-        done();
     });
 
-    it("should return TypeError for text argument", function(done) {
+    it("should return TypeError for text argument", () => {
         let err;
 
         err = window.screenReaderSpeak(1);
@@ -113,11 +104,9 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(TypeError);
         expect(err.message).toBe("Invalid argument text, expect string, get function");
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should return TypeError for priority argument", function(done) {
+    it("should return TypeError for priority argument", () => {
         let err;
         let div;
 
@@ -173,27 +162,23 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(TypeError);
         expect(err.message).toBe("Invalid argument priority, expect string, get function");
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should block xss html", function(done) {
-        let err = window.screenReaderSpeak("<img src='x' onerror='alert(1)'>");
+    it("should block xss html", () => {
+        let err = window.screenReaderSpeak("<img src='x' onerror='alert(1)' alt=''>");
         expect(err).toBeUndefined();
 
         jest.advanceTimersByTime(100);
         const div = getFirstDivInBody();
-        expect(div.innerHTML).toBe("&lt;img src='x' onerror='alert(1)'&gt;");
+        expect(div.innerHTML).toBe("&lt;img src='x' onerror='alert(1)' alt=''&gt;");
 
         jest.advanceTimersByTime(1000);
         jest.clearAllTimers();
 
         expect(getFirstDivInBody()).toBeUndefined();
-
-        done();
     });
 
-    it("should use correct aria-live values", function(done) {
+    it("should use correct aria-live values", () => {
         let err;
         let div;
 
@@ -238,11 +223,9 @@ describe("screen-reader-speak", function(){
         expect(div.getAttribute("aria-live")).toBe("polite");
         document.body.innerHTML = `<html lang="en"><body></body></html>`;
         jest.clearAllTimers();
-
-        done();
     });
 
-    it("should not throw error when manipulate dom after purged", function(done) {
+    it("should not throw error when manipulate dom after purged", () => {
         let err = window.screenReaderSpeak("");
         expect(err).toBeUndefined();
 
@@ -250,11 +233,9 @@ describe("screen-reader-speak", function(){
 
         jest.advanceTimersByTime(100);
         jest.advanceTimersByTime(1000);
-
-        done();
     });
 
-    it("should not throw error when manipulate dom after having undefined document.body + should do return ReferenceError when having no document.body", function(done) {
+    it("should not throw error when manipulate dom after having undefined document.body + should do return ReferenceError when having no document.body", () => {
         let err = window.screenReaderSpeak("");
         expect(err).toBeUndefined();
 
@@ -270,7 +251,5 @@ describe("screen-reader-speak", function(){
         expect(err).toBeInstanceOf(ReferenceError);
         expect(err.message).toBe("document.body not exist");
         jest.clearAllTimers();
-
-        done();
     });
 });


### PR DESCRIPTION
* move `.eslintrc.json` to `src` folder
* create a new `.eslintrc.json` for `tests` folder
* update tests files to fit with new lint rules and jest 29
* update package.json
  * add `@types/jest`
  * update `npm run eslint` command to check also `tests` folder